### PR TITLE
Use 'inject' rather than 'type' property for Wirebox

### DIFF
--- a/logbox-in-a-coldbox-application/the-logbox-injection-dsl.md
+++ b/logbox-in-a-coldbox-application/the-logbox-injection-dsl.md
@@ -13,7 +13,7 @@ Below you can see the most common usage of this dependency DSL:
 
 ```javascript
 //  LogBox wired in
-property name="logBox" type="logbox";
+property name="logBox" inject="logbox";
 
 //  Root Logger
 property name="logger" type="logbox:root";


### PR DESCRIPTION
For me, I was unable to get WireBox to inject without using the 'inject' property, instead of the 'type' property.

The same could be true of the other examples, but I just didn't test them.